### PR TITLE
update URL: mike.biful.co -> mikebifulco.com

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -131,7 +131,7 @@
 - [Mbithe Nzomo](http://decodegirl.com/)
 - [Michael Malura](https://malura.de/)
 - [Mike Behnke](https://kgrz.io/)
-- [Mike Bifulco](https://mike.biful.co/)
+- [Mike Bifulco](https://mikebifulco.com/)
 - [Mouse Reeve](https://www.mousereeve.com/)
 - [Mustafa Çalap](https://calap.co/blog)
 - [Nate Amack](https://nateamack.com/)


### PR DESCRIPTION
Hi there, proposing an update to the entry for my blog - I've moved to a `.com` domain